### PR TITLE
Heap-based callstack to implicit callstack conversion

### DIFF
--- a/src/object/array.rs
+++ b/src/object/array.rs
@@ -1,245 +1,245 @@
-use crate::program::Program;
-use crate::utils::IntoVmResult;
-use crate::value::Value;
-use crate::vm::ops::OpCode;
-use crate::vm::{Result as VmResult, Vm, VmErrorKind};
-use serde::{Deserialize, Serialize};
-use std::ops::{Deref, DerefMut};
+// use crate::program::Program;
+// use crate::utils::IntoVmResult;
+// use crate::value::Value;
+// use crate::vm::ops::OpCode;
+// use crate::vm::{Result as VmResult, Vm, VmErrorKind};
+// use serde::{Deserialize, Serialize};
+// use std::ops::{Deref, DerefMut};
 
-use super::{VmObject, VmType};
+// use super::{VmObject, VmType};
 
-#[derive(Clone, PartialEq, PartialOrd, Debug, Default, Serialize, Deserialize)]
-pub struct Array(pub Vec<Value>);
+// #[derive(Clone, PartialEq, PartialOrd, Debug, Default, Serialize, Deserialize)]
+// pub struct Array(pub Vec<Value>);
 
-impl Array {
-    pub const fn new() -> Self {
-        Self(Vec::new())
-    }
+// impl Array {
+//     pub const fn new() -> Self {
+//         Self(Vec::new())
+//     }
 
-    pub fn with_capacity(capacity: usize) -> Self {
-        Self(Vec::with_capacity(capacity))
-    }
+//     pub fn with_capacity(capacity: usize) -> Self {
+//         Self(Vec::with_capacity(capacity))
+//     }
 
-    fn vm_new(vm: &mut Vm) -> VmResult<Value> {
-        let this_ref = vm.alloc(Self::new())?;
+//     fn vm_new(vm: &mut Vm) -> VmResult<Value> {
+//         let this_ref = vm.alloc(Self::new())?;
 
-        Ok(Value::Reference(this_ref))
-    }
+//         Ok(Value::Reference(this_ref))
+//     }
 
-    fn vm_length(vm: &mut Vm) -> VmResult<Value> {
-        let this_ref = vm.pop_reference()?;
-        let len = vm.heap_object::<Self>(this_ref)?.len();
+//     fn vm_length(vm: &mut Vm) -> VmResult<Value> {
+//         let this_ref = vm.pop_reference()?;
+//         let len = vm.heap_object::<Self>(this_ref)?.len();
 
-        Ok(Value::UInt(len as u64))
-    }
+//         Ok(Value::UInt(len as u64))
+//     }
 
-    fn vm_index(vm: &mut Vm) -> VmResult<Value> {
-        let this_ref = vm.pop_reference()?;
-        let index: usize = vm
-            .pop_uint()?
-            .try_into()
-            .vm_result(VmErrorKind::OutOfBounds, vm.frame())?;
+//     fn vm_index(vm: &mut Vm) -> VmResult<Value> {
+//         let this_ref = vm.pop_reference()?;
+//         let index: usize = vm
+//             .pop_uint()?
+//             .try_into()
+//             .vm_result(VmErrorKind::OutOfBounds, vm.frame())?;
 
-        let value = vm
-            .heap_object::<Self>(this_ref)?
-            .get(index)
-            .copied()
-            .vm_result(VmErrorKind::OutOfBounds, vm.frame())?;
+//         let value = vm
+//             .heap_object::<Self>(this_ref)?
+//             .get(index)
+//             .copied()
+//             .vm_result(VmErrorKind::OutOfBounds, vm.frame())?;
 
-        Ok(value)
-    }
+//         Ok(value)
+//     }
 
-    fn vm_with_capacity(vm: &mut Vm) -> VmResult<Value> {
-        // Using isize::MAX as a maximum bound ensures that the capacity cannot exceed the bounds
-        // of usize, so the `as` casts here are fine. This is also a degenerate case that will
-        // likely cause an OOM error in Rust anyway.
-        let capacity = vm.pop_uint()?.max(isize::MAX as u64) as usize;
-        let this_ref = vm.alloc(Self::with_capacity(capacity))?;
+//     fn vm_with_capacity(vm: &mut Vm) -> VmResult<Value> {
+//         // Using isize::MAX as a maximum bound ensures that the capacity cannot exceed the bounds
+//         // of usize, so the `as` casts here are fine. This is also a degenerate case that will
+//         // likely cause an OOM error in Rust anyway.
+//         let capacity = vm.pop_uint()?.max(isize::MAX as u64) as usize;
+//         let this_ref = vm.alloc(Self::with_capacity(capacity))?;
 
-        Ok(Value::Reference(this_ref))
-    }
+//         Ok(Value::Reference(this_ref))
+//     }
 
-    fn vm_capacity(vm: &mut Vm) -> VmResult<Value> {
-        let this = vm.pop_reference()?;
-        let capacity = vm.heap_object::<Self>(this)?.capacity();
+//     fn vm_capacity(vm: &mut Vm) -> VmResult<Value> {
+//         let this = vm.pop_reference()?;
+//         let capacity = vm.heap_object::<Self>(this)?.capacity();
 
-        Ok(Value::UInt(capacity as u64))
-    }
+//         Ok(Value::UInt(capacity as u64))
+//     }
 
-    fn vm_reserve(vm: &mut Vm) -> VmResult<Value> {
-        let this = vm.pop_reference()?;
-        let additional: usize = vm
-            .pop_uint()?
-            .try_into()
-            .vm_result(VmErrorKind::OutOfBounds, vm.frame())?;
+//     fn vm_reserve(vm: &mut Vm) -> VmResult<Value> {
+//         let this = vm.pop_reference()?;
+//         let additional: usize = vm
+//             .pop_uint()?
+//             .try_into()
+//             .vm_result(VmErrorKind::OutOfBounds, vm.frame())?;
 
-        vm.heap_object_mut::<Self>(this)?.reserve(additional);
-        Ok(Value::Null)
-    }
+//         vm.heap_object_mut::<Self>(this)?.reserve(additional);
+//         Ok(Value::Null)
+//     }
 
-    fn vm_shrink_to_fit(vm: &mut Vm) -> VmResult<Value> {
-        let this = vm.pop_reference()?;
-        vm.heap_object_mut::<Self>(this)?.shrink_to_fit();
+//     fn vm_shrink_to_fit(vm: &mut Vm) -> VmResult<Value> {
+//         let this = vm.pop_reference()?;
+//         vm.heap_object_mut::<Self>(this)?.shrink_to_fit();
 
-        Ok(Value::Null)
-    }
+//         Ok(Value::Null)
+//     }
 
-    fn vm_shrink_to(vm: &mut Vm) -> VmResult<Value> {
-        let this = vm.pop_reference()?;
-        let min_capacity = vm.pop_uint()?.max(isize::MAX as u64) as usize;
+//     fn vm_shrink_to(vm: &mut Vm) -> VmResult<Value> {
+//         let this = vm.pop_reference()?;
+//         let min_capacity = vm.pop_uint()?.max(isize::MAX as u64) as usize;
 
-        vm.heap_object_mut::<Self>(this)?.shrink_to(min_capacity);
+//         vm.heap_object_mut::<Self>(this)?.shrink_to(min_capacity);
 
-        Ok(Value::Null)
-    }
+//         Ok(Value::Null)
+//     }
 
-    fn vm_truncate(vm: &mut Vm) -> VmResult<Value> {
-        let this = vm.pop_reference()?;
-        let len = vm.pop_uint()?.max(isize::MAX as u64) as usize;
+//     fn vm_truncate(vm: &mut Vm) -> VmResult<Value> {
+//         let this = vm.pop_reference()?;
+//         let len = vm.pop_uint()?.max(isize::MAX as u64) as usize;
 
-        vm.heap_object_mut::<Self>(this)?.truncate(len);
+//         vm.heap_object_mut::<Self>(this)?.truncate(len);
 
-        Ok(Value::Null)
-    }
+//         Ok(Value::Null)
+//     }
 
-    fn vm_swap_remove(vm: &mut Vm) -> VmResult<Value> {
-        let this_ref = vm.pop_reference()?;
-        let idx: usize = vm
-            .pop_uint()?
-            .try_into()
-            .vm_result(VmErrorKind::OutOfBounds, vm.frame())?;
+//     fn vm_swap_remove(vm: &mut Vm) -> VmResult<Value> {
+//         let this_ref = vm.pop_reference()?;
+//         let idx: usize = vm
+//             .pop_uint()?
+//             .try_into()
+//             .vm_result(VmErrorKind::OutOfBounds, vm.frame())?;
 
-        let this = vm.heap_object_mut::<Self>(this_ref)?;
+//         let this = vm.heap_object_mut::<Self>(this_ref)?;
 
-        if idx < this.len() {
-            let value = this.swap_remove(idx);
-            Ok(value)
-        } else {
-            Err(vm.error(VmErrorKind::OutOfBounds))
-        }
-    }
+//         if idx < this.len() {
+//             let value = this.swap_remove(idx);
+//             Ok(value)
+//         } else {
+//             Err(vm.error(VmErrorKind::OutOfBounds))
+//         }
+//     }
 
-    fn vm_insert(vm: &mut Vm) -> VmResult<Value> {
-        let this_ref = vm.pop_reference()?;
-        let idx: usize = vm
-            .pop_uint()?
-            .try_into()
-            .vm_result(VmErrorKind::OutOfBounds, vm.frame())?;
-        let value = vm.pop_value()?;
+//     fn vm_insert(vm: &mut Vm) -> VmResult<Value> {
+//         let this_ref = vm.pop_reference()?;
+//         let idx: usize = vm
+//             .pop_uint()?
+//             .try_into()
+//             .vm_result(VmErrorKind::OutOfBounds, vm.frame())?;
+//         let value = vm.pop_value()?;
 
-        let this = vm.heap_object_mut::<Self>(this_ref)?;
+//         let this = vm.heap_object_mut::<Self>(this_ref)?;
 
-        if idx <= this.len() {
-            this.insert(idx, value);
-            Ok(Value::Null)
-        } else {
-            Err(vm.error(VmErrorKind::OutOfBounds))
-        }
-    }
+//         if idx <= this.len() {
+//             this.insert(idx, value);
+//             Ok(Value::Null)
+//         } else {
+//             Err(vm.error(VmErrorKind::OutOfBounds))
+//         }
+//     }
 
-    fn vm_remove(vm: &mut Vm) -> VmResult<Value> {
-        let this_ref = vm.pop_reference()?;
-        let idx: usize = vm
-            .pop_uint()?
-            .try_into()
-            .vm_result(VmErrorKind::OutOfBounds, vm.frame())?;
+//     fn vm_remove(vm: &mut Vm) -> VmResult<Value> {
+//         let this_ref = vm.pop_reference()?;
+//         let idx: usize = vm
+//             .pop_uint()?
+//             .try_into()
+//             .vm_result(VmErrorKind::OutOfBounds, vm.frame())?;
 
-        let this = vm.heap_object_mut::<Self>(this_ref)?;
+//         let this = vm.heap_object_mut::<Self>(this_ref)?;
 
-        if idx < this.len() {
-            let value = this.remove(idx);
-            Ok(value)
-        } else {
-            Err(vm.error(VmErrorKind::OutOfBounds))
-        }
-    }
+//         if idx < this.len() {
+//             let value = this.remove(idx);
+//             Ok(value)
+//         } else {
+//             Err(vm.error(VmErrorKind::OutOfBounds))
+//         }
+//     }
 
-    fn vm_push(vm: &mut Vm) -> VmResult<Value> {
-        let this_ref = vm.pop_reference()?;
-        let value = vm.pop_value()?;
+//     fn vm_push(vm: &mut Vm) -> VmResult<Value> {
+//         let this_ref = vm.pop_reference()?;
+//         let value = vm.pop_value()?;
 
-        vm.heap_object_mut::<Self>(this_ref)?.push(value);
+//         vm.heap_object_mut::<Self>(this_ref)?.push(value);
 
-        Ok(Value::Null)
-    }
+//         Ok(Value::Null)
+//     }
 
-    fn vm_pop(vm: &mut Vm) -> VmResult<Value> {
-        let this_ref = vm.pop_reference()?;
+//     fn vm_pop(vm: &mut Vm) -> VmResult<Value> {
+//         let this_ref = vm.pop_reference()?;
 
-        let value = vm
-            .heap_object_mut::<Self>(this_ref)?
-            .pop()
-            .vm_result(VmErrorKind::OutOfBounds, vm.frame())?;
+//         let value = vm
+//             .heap_object_mut::<Self>(this_ref)?
+//             .pop()
+//             .vm_result(VmErrorKind::OutOfBounds, vm.frame())?;
 
-        Ok(value)
-    }
-}
+//         Ok(value)
+//     }
+// }
 
-impl Deref for Array {
-    type Target = Vec<Value>;
+// impl Deref for Array {
+//     type Target = Vec<Value>;
 
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+//     fn deref(&self) -> &Self::Target {
+//         &self.0
+//     }
+// }
 
-impl DerefMut for Array {
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut self.0
-    }
-}
+// impl DerefMut for Array {
+//     fn deref_mut(&mut self) -> &mut Self::Target {
+//         &mut self.0
+//     }
+// }
 
-impl VmObject for Array {
-    fn register_type(program: &mut Program) -> &VmType
-    where
-        Self: Sized,
-    {
-        let ty_name = "Array";
+// impl VmObject for Array {
+//     fn register_type(program: &mut Program) -> &VmType
+//     where
+//         Self: Sized,
+//     {
+//         let ty_name = "Array";
 
-        let mut ty = VmType::new(ty_name);
+//         let mut ty = VmType::new(ty_name);
 
-        let native_funcs = [
-            ("new", Array::vm_new as fn(&mut Vm) -> _),
-            ("index", Array::vm_index),
-            ("length", Array::vm_length),
-            ("push", Array::vm_push),
-            ("pop", Array::vm_pop),
-            ("insert", Array::vm_insert),
-            ("remove", Array::vm_remove),
-            ("swap_remove", Array::vm_swap_remove),
-            ("reserve", Array::vm_reserve),
-        ];
+//         let native_funcs = [
+//             ("new", Array::vm_new as fn(&mut Vm) -> _),
+//             ("index", Array::vm_index),
+//             ("length", Array::vm_length),
+//             ("push", Array::vm_push),
+//             ("pop", Array::vm_pop),
+//             ("insert", Array::vm_insert),
+//             ("remove", Array::vm_remove),
+//             ("swap_remove", Array::vm_swap_remove),
+//             ("reserve", Array::vm_reserve),
+//         ];
 
-        for (name, func) in native_funcs {
-            let native_name = [ty_name, "::", name];
-            let native_sym = program.define_symbol_iter(native_name);
+//         for (name, func) in native_funcs {
+//             let native_name = [ty_name, "::", name];
+//             let native_sym = program.define_symbol_iter(native_name);
 
-            program
-                .define_native_function(native_sym, func)
-                .unwrap_or_else(|_| {
-                    panic!(
-                        "native method {} already defined on type {ty_name}",
-                        String::from_iter(native_name)
-                    )
-                });
+//             program
+//                 .define_native_function(native_sym, func)
+//                 .unwrap_or_else(|_| {
+//                     panic!(
+//                         "native method {} already defined on type {ty_name}",
+//                         String::from_iter(native_name)
+//                     )
+//                 });
 
-            // methods on Array simply forward to the native implementation, so the methods are
-            // pretty trivial.
-            ty.with_method(name, [OpCode::CallNative(native_sym), OpCode::Ret]);
-        }
+//             // methods on Array simply forward to the native implementation, so the methods are
+//             // pretty trivial.
+//             ty.with_method(name, [OpCode::CallNative(native_sym), OpCode::Ret]);
+//         }
 
-        program.register_type(ty)
-    }
+//         program.register_type(ty)
+//     }
 
-    fn field(&self, _: &str) -> Option<&Value> {
-        None
-    }
+//     fn field(&self, _: &str) -> Option<&Value> {
+//         None
+//     }
 
-    fn field_mut(&mut self, _: &str) -> Option<&mut Value> {
-        None
-    }
+//     fn field_mut(&mut self, _: &str) -> Option<&mut Value> {
+//         None
+//     }
 
-    fn data(&self) -> &[Value] {
-        &self.0
-    }
-}
+//     fn data(&self) -> &[Value] {
+//         &self.0
+//     }
+// }

--- a/src/vm/ops.rs
+++ b/src/vm/ops.rs
@@ -6,6 +6,7 @@ use serde::{Deserialize, Serialize};
 use std::{ops::Index, slice::SliceIndex, sync::Arc};
 
 use super::function::NewFunction;
+use super::CallFrame;
 
 pub type OpResult = VmResult<Transition>;
 
@@ -173,64 +174,64 @@ pub enum OpCode {
 }
 
 impl OpCode {
-    pub fn execute(self, vm: &mut Vm) -> OpResult {
+    pub fn execute(self, vm: &mut Vm, frame: &mut CallFrame) -> OpResult {
         use OpCode as Op;
 
         match self {
             Op::NoOp => vm.op_nop(),
             Op::Halt => vm.op_halt(),
-            Op::Push(value) => vm.op_push(value),
-            Op::Pop => vm.op_pop(),
-            Op::Load(index) => vm.op_load(index),
-            Op::Store(index) => vm.op_store(index),
-            Op::Dup => vm.op_dup(),
-            Op::Reserve => vm.op_reserve(),
-            Op::ReserveImm(n) => vm.op_reserve_imm(n),
-            Op::Add => vm.op_add(),
-            Op::AddImm(value) => vm.op_add_imm(value),
-            Op::Sub => vm.op_sub(),
-            Op::SubImm(value) => vm.op_sub_imm(value),
-            Op::Mul => vm.op_mul(),
-            Op::MulImm(value) => vm.op_mul_imm(value),
-            Op::Div => vm.op_div(),
-            Op::DivImm(value) => vm.op_div_imm(value),
-            Op::Rem => vm.op_rem(),
-            Op::RemImm(value) => vm.op_rem_imm(value),
-            Op::And => vm.op_and(),
-            Op::AndImm(value) => vm.op_and_imm(value),
-            Op::Or => vm.op_or(),
-            Op::OrImm(value) => vm.op_or_imm(value),
-            Op::Xor => vm.op_xor(),
-            Op::XorImm(value) => vm.op_xor_imm(value),
-            Op::Not => vm.op_not(),
-            Op::Shr => vm.op_shr(),
-            Op::ShrImm(value) => vm.op_shr_imm(value),
-            Op::Shl => vm.op_shl(),
-            Op::ShlImm(value) => vm.op_shl_imm(value),
-            Op::Eq => vm.op_eq(),
-            Op::EqImm(value) => vm.op_eq_imm(value),
-            Op::Gt => vm.op_gt(),
-            Op::GtImm(value) => vm.op_gt_imm(value),
-            Op::Ge => vm.op_ge(),
-            Op::GeImm(value) => vm.op_ge_imm(value),
-            Op::Lt => vm.op_lt(),
-            Op::LtImm(value) => vm.op_lt_imm(value),
-            Op::Le => vm.op_le(),
-            Op::LeImm(value) => vm.op_le_imm(value),
-            Op::Jump => vm.op_jump(),
-            Op::JumpImm(address) => vm.op_jump_imm(address),
-            Op::JumpCond => vm.op_jump_cond(),
-            Op::JumpCondImm(address) => vm.op_jump_cond_imm(address),
-            Op::Call => vm.op_call(),
-            Op::CallImm(symbol) => vm.op_call_imm(symbol),
-            Op::CallNative(index) => vm.op_call_native(index),
-            Op::Ret => vm.op_ret(),
-            Op::CastUint => vm.op_cast_uint(),
-            Op::CastSint => vm.op_cast_sint(),
-            Op::CastFloat => vm.op_cast_float(),
-            Op::CastBool => vm.op_cast_bool(),
-            Op::Dbg(address) => vm.op_dbg(address),
-            Op::DbgVm => vm.op_dbg_vm(),
+            Op::Push(value) => vm.op_push(value, frame),
+            Op::Pop => vm.op_pop(frame),
+            Op::Load(index) => vm.op_load(index, frame),
+            Op::Store(index) => vm.op_store(index, frame),
+            Op::Dup => vm.op_dup(frame),
+            Op::Reserve => vm.op_reserve(frame),
+            Op::ReserveImm(n) => vm.op_reserve_imm(n, frame),
+            Op::Add => vm.op_add(frame),
+            Op::AddImm(value) => vm.op_add_imm(value, frame),
+            Op::Sub => vm.op_sub(frame),
+            Op::SubImm(value) => vm.op_sub_imm(value, frame),
+            Op::Mul => vm.op_mul(frame),
+            Op::MulImm(value) => vm.op_mul_imm(value, frame),
+            Op::Div => vm.op_div(frame),
+            Op::DivImm(value) => vm.op_div_imm(value, frame),
+            Op::Rem => vm.op_rem(frame),
+            Op::RemImm(value) => vm.op_rem_imm(value, frame),
+            Op::And => vm.op_and(frame),
+            Op::AndImm(value) => vm.op_and_imm(value, frame),
+            Op::Or => vm.op_or(frame),
+            Op::OrImm(value) => vm.op_or_imm(value, frame),
+            Op::Xor => vm.op_xor(frame),
+            Op::XorImm(value) => vm.op_xor_imm(value, frame),
+            Op::Not => vm.op_not(frame),
+            Op::Shr => vm.op_shr(frame),
+            Op::ShrImm(value) => vm.op_shr_imm(value, frame),
+            Op::Shl => vm.op_shl(frame),
+            Op::ShlImm(value) => vm.op_shl_imm(value, frame),
+            Op::Eq => vm.op_eq(frame),
+            Op::EqImm(value) => vm.op_eq_imm(value, frame),
+            Op::Gt => vm.op_gt(frame),
+            Op::GtImm(value) => vm.op_gt_imm(value, frame),
+            Op::Ge => vm.op_ge(frame),
+            Op::GeImm(value) => vm.op_ge_imm(value, frame),
+            Op::Lt => vm.op_lt(frame),
+            Op::LtImm(value) => vm.op_lt_imm(value, frame),
+            Op::Le => vm.op_le(frame),
+            Op::LeImm(value) => vm.op_le_imm(value, frame),
+            Op::Jump => vm.op_jump(frame),
+            Op::JumpImm(address) => vm.op_jump_imm(address, frame),
+            Op::JumpCond => vm.op_jump_cond(frame),
+            Op::JumpCondImm(address) => vm.op_jump_cond_imm(address, frame),
+            Op::Call => vm.op_call(frame),
+            Op::CallImm(symbol) => vm.op_call_imm(symbol, frame),
+            Op::CallNative(index) => vm.op_call_native(index, frame),
+            Op::Ret => vm.op_ret(frame),
+            Op::CastUint => vm.op_cast_uint(frame),
+            Op::CastSint => vm.op_cast_sint(frame),
+            Op::CastFloat => vm.op_cast_float(frame),
+            Op::CastBool => vm.op_cast_bool(frame),
+            Op::Dbg(address) => vm.op_dbg(address, frame),
+            Op::DbgVm => vm.op_dbg_vm(frame),
         }
     }
 }
@@ -239,6 +240,7 @@ impl OpCode {
 pub enum Transition {
     Continue,
     Jump,
+    Return,
     Halt,
 }
 
@@ -260,20 +262,21 @@ mod imp {
             a = $a:expr,
             b = $b:expr,
             int_op = $int_op:ident,
-            float_op = $float_op:ident $(,)?
+            float_op = $float_op:ident, 
+            frame = $frame:expr $(,)?
         ) => {{
             match ($a, $b) {
                 (Value::UInt(a), Value::UInt(b)) => {
                     let new_value = match u64::$int_op(a, *b) {
                         Some(v) => v,
-                        None => return Err(VmError::new(VmErrorKind::Arithmetic, &$self.frame)),
+                        None => return Err(VmError::new(VmErrorKind::Arithmetic, $frame)),
                     };
                     *b = new_value;
                 }
                 (Value::SInt(a), Value::SInt(b)) => {
                     let new_value = match i64::$int_op(a, *b) {
                         Some(v) => v,
-                        None => return Err(VmError::new(VmErrorKind::Arithmetic, &$self.frame)),
+                        None => return Err(VmError::new(VmErrorKind::Arithmetic, $frame)),
                     };
                     *b = new_value;
                 }
@@ -283,11 +286,11 @@ mod imp {
                 (Value::Address(a), Value::Address(b)) => {
                     let new_value = match usize::$int_op(a, *b) {
                         Some(v) => v,
-                        None => return Err(VmError::new(VmErrorKind::Arithmetic, &$self.frame)),
+                        None => return Err(VmError::new(VmErrorKind::Arithmetic, $frame)),
                     };
                     *b = new_value;
                 }
-                _ => return Err(VmError::new(VmErrorKind::Type, &$self.frame)),
+                _ => return Err(VmError::new(VmErrorKind::Type, $frame)),
             }
 
             Ok(Transition::Continue)
@@ -299,20 +302,21 @@ mod imp {
             a = $a:expr,
             imm = $b:expr,
             int_op = $int_op:ident,
-            float_op = $float_op:ident $(,)?
+            float_op = $float_op:ident,
+            frame = $frame:expr $(,)?
         ) => {{
             match ($a, $b) {
                 (Value::UInt(a), Value::UInt(b)) => {
                     let new_value = match u64::$int_op(*a, b) {
                         Some(v) => v,
-                        None => return Err(VmError::new(VmErrorKind::Arithmetic, &$self.frame)),
+                        None => return Err(VmError::new(VmErrorKind::Arithmetic, $frame)),
                     };
                     *a = new_value;
                 }
                 (Value::SInt(a), Value::SInt(b)) => {
                     let new_value = match i64::$int_op(*a, b) {
                         Some(v) => v,
-                        None => return Err(VmError::new(VmErrorKind::Arithmetic, &$self.frame)),
+                        None => return Err(VmError::new(VmErrorKind::Arithmetic, $frame)),
                     };
                     *a = new_value;
                 }
@@ -322,11 +326,11 @@ mod imp {
                 (Value::Address(a), Value::Address(b)) => {
                     let new_value = match usize::$int_op(*a, b) {
                         Some(v) => v,
-                        None => return Err(VmError::new(VmErrorKind::Arithmetic, &$self.frame)),
+                        None => return Err(VmError::new(VmErrorKind::Arithmetic, $frame)),
                     };
                     *a = new_value;
                 }
-                _ => return Err(VmError::new(VmErrorKind::Type, &$self.frame)),
+                _ => return Err(VmError::new(VmErrorKind::Type, $frame)),
             }
 
             Ok(Transition::Continue)
@@ -338,7 +342,8 @@ mod imp {
         vm = $self:ident,
         a = $a:expr,
         b = $b:expr,
-        op = $op:path,$(,)?
+        op = $op:path,
+        frame = $frame:expr $(,)?
     ) => {{
             match ($a, $b) {
                 (Value::UInt(a), Value::UInt(b)) => {
@@ -357,7 +362,7 @@ mod imp {
                     let new_value = $op(a, *b);
                     *b = new_value;
                 }
-                _ => return Err($self.error(VmErrorKind::Type)),
+                _ => return Err($self.error(VmErrorKind::Type, $frame)),
             }
 
             Ok(Transition::Continue)
@@ -366,7 +371,8 @@ mod imp {
             vm = $self:ident,
             a = $a:expr,
             imm = $b:expr,
-            op = $op:path,$(,)?
+            op = $op:path,
+            frame = $frame:expr $(,)?
         ) => {{
             match ($a, $b) {
                 (Value::UInt(a), Value::UInt(b)) => {
@@ -385,7 +391,7 @@ mod imp {
                     let new_value = $op(*a, b);
                     *a = new_value;
                 }
-                _ => return Err($self.error(VmErrorKind::Type)),
+                _ => return Err($self.error(VmErrorKind::Type, $frame)),
             }
 
             Ok(Transition::Continue)
@@ -397,7 +403,8 @@ mod imp {
         vm = $self:ident,
         a = $a:expr,
         b = $b:expr,
-        op = $op:ident $(,)?
+        op = $op:ident,
+        frame = $frame:expr $(,)?
     ) => {{
             // This one has to be different, since `top` might be a differnt variant than `$a`, so
             // the variant has to be changed out when reassigning to it.
@@ -406,16 +413,16 @@ mod imp {
                     let operand_res: Result<u32, _> = match top {
                         Value::UInt(v) => (*v).try_into(),
                         Value::SInt(v) => (*v).try_into(),
-                        _ => return Err(VmError::new(VmErrorKind::Type, &$self.frame)),
+                        _ => return Err(VmError::new(VmErrorKind::Type, $frame)),
                     };
 
                     let Ok(b) = operand_res else {
-                        return Err(VmError::new(VmErrorKind::Arithmetic, &$self.frame));
+                        return Err(VmError::new(VmErrorKind::Arithmetic, $frame));
                     };
 
                     let new_value = match u64::$op(a, b) {
                         Some(v) => v,
-                        None => return Err(VmError::new(VmErrorKind::Arithmetic, &$self.frame)),
+                        None => return Err(VmError::new(VmErrorKind::Arithmetic, $frame)),
                     };
 
                     *top = Value::UInt(new_value);
@@ -424,16 +431,16 @@ mod imp {
                     let operand_res: Result<u32, _> = match top {
                         Value::UInt(v) => (*v).try_into(),
                         Value::SInt(v) => (*v).try_into(),
-                        _ => return Err(VmError::new(VmErrorKind::Type, &$self.frame)),
+                        _ => return Err(VmError::new(VmErrorKind::Type, $frame)),
                     };
 
                     let Ok(b) = operand_res else {
-                        return Err(VmError::new(VmErrorKind::Arithmetic, &$self.frame));
+                        return Err(VmError::new(VmErrorKind::Arithmetic, $frame));
                     };
 
                     let new_value = match i64::$op(a, b) {
                         Some(v) => v,
-                        None => return Err(VmError::new(VmErrorKind::Arithmetic, &$self.frame)),
+                        None => return Err(VmError::new(VmErrorKind::Arithmetic, $frame)),
                     };
 
                     *top = Value::SInt(new_value);
@@ -442,22 +449,22 @@ mod imp {
                     let operand_res: Result<u32, _> = match top {
                         Value::UInt(v) => (*v).try_into(),
                         Value::SInt(v) => (*v).try_into(),
-                        _ => return Err(VmError::new(VmErrorKind::Type, &$self.frame)),
+                        _ => return Err(VmError::new(VmErrorKind::Type, $frame)),
                     };
 
                     let Ok(b) = operand_res else {
-                        return Err(VmError::new(VmErrorKind::Arithmetic, &$self.frame));
+                        return Err(VmError::new(VmErrorKind::Arithmetic, $frame));
                     };
 
                     let new_value = match usize::$op(a, b) {
                         Some(v) => v,
-                        None => return Err(VmError::new(VmErrorKind::Arithmetic, &$self.frame)),
+                        None => return Err(VmError::new(VmErrorKind::Arithmetic, $frame)),
                     };
 
                     *top = Value::Address(new_value);
                 }
 
-                _ => return Err(VmError::new(VmErrorKind::Type, &$self.frame)),
+                _ => return Err(VmError::new(VmErrorKind::Type, $frame)),
             }
 
             Ok(Transition::Continue)
@@ -466,18 +473,19 @@ mod imp {
             vm = $self:ident,
             a = $a:expr,
             imm = $b:expr,
-            op = $op:ident $(,)?
+            op = $op:ident,
+            frame = $frame:expr $(,)?
         ) => {{
             match ($a, $b) {
                 (Value::UInt(a), Value::UInt(b)) => {
                     let b = match u32::try_from(b) {
                         Ok(v) => v,
-                        Err(_) => return Err(VmError::new(VmErrorKind::Arithmetic, &$self.frame)),
+                        Err(_) => return Err(VmError::new(VmErrorKind::Arithmetic, $frame)),
                     };
 
                     let new_value = match u64::$op(*a, b) {
                         Some(v) => v,
-                        None => return Err(VmError::new(VmErrorKind::Arithmetic, &$self.frame)),
+                        None => return Err(VmError::new(VmErrorKind::Arithmetic, $frame)),
                     };
 
                     *a = new_value;
@@ -485,12 +493,12 @@ mod imp {
                 (Value::UInt(a), Value::SInt(b)) => {
                     let b = match u32::try_from(b) {
                         Ok(v) => v,
-                        Err(_) => return Err(VmError::new(VmErrorKind::Arithmetic, &$self.frame)),
+                        Err(_) => return Err(VmError::new(VmErrorKind::Arithmetic, $frame)),
                     };
 
                     let new_value = match u64::$op(*a, b) {
                         Some(v) => v,
-                        None => return Err(VmError::new(VmErrorKind::Arithmetic, &$self.frame)),
+                        None => return Err(VmError::new(VmErrorKind::Arithmetic, $frame)),
                     };
 
                     *a = new_value;
@@ -498,12 +506,12 @@ mod imp {
                 (Value::SInt(a), Value::SInt(b)) => {
                     let b = match u32::try_from(b) {
                         Ok(v) => v,
-                        Err(_) => return Err(VmError::new(VmErrorKind::Arithmetic, &$self.frame)),
+                        Err(_) => return Err(VmError::new(VmErrorKind::Arithmetic, $frame)),
                     };
 
                     let new_value = match i64::$op(*a, b) {
                         Some(v) => v,
-                        None => return Err(VmError::new(VmErrorKind::Arithmetic, &$self.frame)),
+                        None => return Err(VmError::new(VmErrorKind::Arithmetic, $frame)),
                     };
 
                     *a = new_value;
@@ -511,12 +519,12 @@ mod imp {
                 (Value::SInt(a), Value::UInt(b)) => {
                     let b = match u32::try_from(b) {
                         Ok(v) => v,
-                        Err(_) => return Err(VmError::new(VmErrorKind::Arithmetic, &$self.frame)),
+                        Err(_) => return Err(VmError::new(VmErrorKind::Arithmetic, $frame)),
                     };
 
                     let new_value = match i64::$op(*a, b) {
                         Some(v) => v,
-                        None => return Err(VmError::new(VmErrorKind::Arithmetic, &$self.frame)),
+                        None => return Err(VmError::new(VmErrorKind::Arithmetic, $frame)),
                     };
 
                     *a = new_value;
@@ -524,12 +532,12 @@ mod imp {
                 (Value::Address(a), Value::Address(b)) => {
                     let b = match u32::try_from(b) {
                         Ok(v) => v,
-                        Err(_) => return Err(VmError::new(VmErrorKind::Arithmetic, &$self.frame)),
+                        Err(_) => return Err(VmError::new(VmErrorKind::Arithmetic, $frame)),
                     };
 
                     let new_value = match usize::$op(*a, b) {
                         Some(v) => v,
-                        None => return Err(VmError::new(VmErrorKind::Arithmetic, &$self.frame)),
+                        None => return Err(VmError::new(VmErrorKind::Arithmetic, $frame)),
                     };
 
                     *a = new_value;
@@ -537,12 +545,12 @@ mod imp {
                 (Value::Address(a), Value::UInt(b)) => {
                     let b = match u32::try_from(b) {
                         Ok(v) => v,
-                        Err(_) => return Err(VmError::new(VmErrorKind::Arithmetic, &$self.frame)),
+                        Err(_) => return Err(VmError::new(VmErrorKind::Arithmetic, $frame)),
                     };
 
                     let new_value = match usize::$op(*a, b) {
                         Some(v) => v,
-                        None => return Err(VmError::new(VmErrorKind::Arithmetic, &$self.frame)),
+                        None => return Err(VmError::new(VmErrorKind::Arithmetic, $frame)),
                     };
 
                     *a = new_value;
@@ -550,17 +558,17 @@ mod imp {
                 (Value::Address(a), Value::SInt(b)) => {
                     let b = match u32::try_from(b) {
                         Ok(v) => v,
-                        Err(_) => return Err(VmError::new(VmErrorKind::Arithmetic, &$self.frame)),
+                        Err(_) => return Err(VmError::new(VmErrorKind::Arithmetic, $frame)),
                     };
 
                     let new_value = match usize::$op(*a, b) {
                         Some(v) => v,
-                        None => return Err(VmError::new(VmErrorKind::Arithmetic, &$self.frame)),
+                        None => return Err(VmError::new(VmErrorKind::Arithmetic, $frame)),
                     };
 
                     *a = new_value;
                 }
-                _ => return Err(VmError::new(VmErrorKind::Type, &$self.frame)),
+                _ => return Err(VmError::new(VmErrorKind::Type, $frame)),
             }
 
             Ok(Transition::Continue)
@@ -573,7 +581,8 @@ mod imp {
         a = $a:expr,
         b = $b:expr,
         null = $null:literal,
-        op = $op:path $(,)?
+        op = $op:path,
+        frame = $frame:expr $(,)?
     ) => {{
             let result = $op(&$a, $b);
 
@@ -586,7 +595,8 @@ mod imp {
             a = $a:expr,
             imm = $b:expr,
             null = $null:literal,
-            op = $op:path $(,)?
+            op = $op:path,
+            frame = $frame:expr $(,)?
         ) => {{
             let result = $op(&*$a, &$b);
 
@@ -608,236 +618,252 @@ mod imp {
         }
 
         // push
-        pub(super) fn op_push(&mut self, value: Value) -> OpResult {
-            self.push_value(value)?;
+        pub(super) fn op_push(&mut self, value: Value, frame: &CallFrame) -> OpResult {
+            self.push_value(value, frame)?;
             Ok(Transition::Continue)
         }
 
         // pop
-        pub(super) fn op_pop(&mut self) -> OpResult {
-            let _ = self.pop_value()?;
+        pub(super) fn op_pop(&mut self, frame: &CallFrame) -> OpResult {
+            let _ = self.pop_value(frame)?;
 
             Ok(Transition::Continue)
         }
 
-        pub(super) fn op_load(&mut self, index: usize) -> OpResult {
-            let value = self.get_local(index)?;
+        pub(super) fn op_load(&mut self, index: usize, frame: &CallFrame) -> OpResult {
+            let value = self.get_local(index, frame)?;
 
-            self.push_value(value)?;
-
-            Ok(Transition::Continue)
-        }
-
-        pub(super) fn op_store(&mut self, index: usize) -> OpResult {
-            let value = self.pop_value()?;
-
-            self.set_local(index, value)?;
+            self.push_value(value, frame)?;
 
             Ok(Transition::Continue)
         }
 
-        pub(super) fn op_dup(&mut self) -> OpResult {
-            let value = self.top_value()?;
-            self.push_value(value)?;
+        pub(super) fn op_store(&mut self, index: usize, frame: &CallFrame) -> OpResult {
+            let value = self.pop_value(frame)?;
+
+            self.set_local(index, value, frame)?;
+
+            Ok(Transition::Continue)
+        }
+
+        pub(super) fn op_dup(&mut self, frame: &CallFrame) -> OpResult {
+            let value = self.top_value(frame)?;
+            self.push_value(value, frame)?;
 
             Ok(Transition::Continue)
         }
 
         // rsrv
-        pub(super) fn op_reserve(&mut self) -> OpResult {
-            let n: usize = match self.pop_value()? {
+        pub(super) fn op_reserve(&mut self, frame: &mut CallFrame) -> OpResult {
+            let n: usize = match self.pop_value(frame)? {
                 Value::UInt(n) => n
                     .try_into()
-                    .vm_result(VmErrorKind::OutOfBounds, &self.frame)?,
+                    .vm_result(VmErrorKind::OutOfBounds, &*frame)?,
                 Value::SInt(n) => n
                     .try_into()
-                    .vm_result(VmErrorKind::OutOfBounds, &self.frame)?,
-                _ => return Err(self.error(VmErrorKind::Type)),
+                    .vm_result(VmErrorKind::OutOfBounds, &*frame)?,
+                _ => return Err(self.error(VmErrorKind::Type, frame)),
             };
 
-            self.op_reserve_imm(n)
+            self.op_reserve_imm(n, frame)
         }
 
         // rsrvi
-        pub(super) fn op_reserve_imm(&mut self, n: usize) -> OpResult {
-            self.set_reserved(n)?;
+        pub(super) fn op_reserve_imm(&mut self, n: usize, frame: &mut CallFrame) -> OpResult {
+            self.set_reserved(n, frame)?;
 
             Ok(Transition::Continue)
         }
 
         // add
-        pub(super) fn op_add(&mut self) -> OpResult {
+        pub(super) fn op_add(&mut self, frame: &CallFrame) -> OpResult {
             bin_arithmetic! {
                 vm = self,
-                a = self.pop_value()?,
-                b = self.top_value_mut()?,
+                a = self.pop_value(frame)?,
+                b = self.top_value_mut(frame)?,
                 int_op = checked_add,
                 float_op = add,
+                frame = frame,
             }
         }
 
         // addi
-        pub(super) fn op_add_imm(&mut self, value: Value) -> OpResult {
+        pub(super) fn op_add_imm(&mut self, value: Value, frame: &CallFrame) -> OpResult {
             bin_arithmetic! {
                 vm = self,
-                a = self.top_value_mut()?,
+                a = self.top_value_mut(frame)?,
                 imm = value,
                 int_op = checked_add,
                 float_op = add,
+                frame = frame,
             }
         }
 
         // sub
-        pub(super) fn op_sub(&mut self) -> OpResult {
+        pub(super) fn op_sub(&mut self, frame: &CallFrame) -> OpResult {
             bin_arithmetic! {
                 vm = self,
-                a = self.pop_value()?,
-                b = self.top_value_mut()?,
+                a = self.pop_value(frame)?,
+                b = self.top_value_mut(frame)?,
                 int_op = checked_sub,
                 float_op = sub,
+                frame = frame,
             }
         }
 
         // subi
-        pub(super) fn op_sub_imm(&mut self, value: Value) -> OpResult {
+        pub(super) fn op_sub_imm(&mut self, value: Value, frame: &CallFrame) -> OpResult {
             bin_arithmetic! {
                 vm = self,
-                a = self.top_value_mut()?,
+                a = self.top_value_mut(frame)?,
                 imm = value,
                 int_op = checked_sub,
                 float_op = sub,
+                frame = frame,
             }
         }
 
         // mul
-        pub(super) fn op_mul(&mut self) -> OpResult {
+        pub(super) fn op_mul(&mut self, frame: &CallFrame) -> OpResult {
             bin_arithmetic! {
                 vm = self,
-                a = self.pop_value()?,
-                b = self.top_value_mut()?,
+                a = self.pop_value(frame)?,
+                b = self.top_value_mut(frame)?,
                 int_op = checked_mul,
                 float_op = mul,
+                frame = frame,
             }
         }
 
         // muli
-        pub(super) fn op_mul_imm(&mut self, value: Value) -> OpResult {
+        pub(super) fn op_mul_imm(&mut self, value: Value, frame: &CallFrame) -> OpResult {
             bin_arithmetic! {
                 vm = self,
-                a = self.top_value_mut()?,
+                a = self.top_value_mut(frame)?,
                 imm = value,
                 int_op = checked_mul,
                 float_op = mul,
+                frame = frame,
             }
         }
 
         // div
-        pub(super) fn op_div(&mut self) -> OpResult {
+        pub(super) fn op_div(&mut self, frame: &CallFrame) -> OpResult {
             bin_arithmetic! {
                 vm = self,
-                a = self.pop_value()?,
-                b = self.top_value_mut()?,
+                a = self.pop_value(frame)?,
+                b = self.top_value_mut(frame)?,
                 int_op = checked_div,
                 float_op = div,
+                frame = frame,
             }
         }
 
         // divi
-        pub(super) fn op_div_imm(&mut self, value: Value) -> OpResult {
+        pub(super) fn op_div_imm(&mut self, value: Value, frame: &CallFrame) -> OpResult {
             bin_arithmetic! {
                 vm = self,
-                a = self.top_value_mut()?,
+                a = self.top_value_mut(frame)?,
                 imm = value,
                 int_op = checked_div,
                 float_op = div,
+                frame = frame,
             }
         }
 
         // rem
-        pub(super) fn op_rem(&mut self) -> OpResult {
+        pub(super) fn op_rem(&mut self, frame: &CallFrame) -> OpResult {
             bin_arithmetic! {
                 vm = self,
-                a = self.pop_value()?,
-                b = self.top_value_mut()?,
+                a = self.pop_value(frame)?,
+                b = self.top_value_mut(frame)?,
                 int_op = checked_rem,
                 float_op = rem,
+                frame = frame,
             }
         }
 
         // remi
-        pub(super) fn op_rem_imm(&mut self, value: Value) -> OpResult {
+        pub(super) fn op_rem_imm(&mut self, value: Value, frame: &CallFrame) -> OpResult {
             bin_arithmetic! {
                 vm = self,
-                a = self.top_value_mut()?,
+                a = self.top_value_mut(frame)?,
                 imm = value,
                 int_op = checked_rem,
                 float_op = rem,
+                frame = frame,
             }
         }
 
         // and
-        pub(super) fn op_and(&mut self) -> OpResult {
+        pub(super) fn op_and(&mut self, frame: &CallFrame) -> OpResult {
             bin_bitwise! {
                 vm = self,
-                a = self.pop_value()?,
-                b = self.top_value_mut()?,
+                a = self.pop_value(frame)?,
+                b = self.top_value_mut(frame)?,
                 op = BitAnd::bitand,
+                frame = frame,
             }
         }
 
         // andi
-        pub(super) fn op_and_imm(&mut self, value: Value) -> OpResult {
+        pub(super) fn op_and_imm(&mut self, value: Value, frame: &CallFrame) -> OpResult {
             bin_bitwise! {
                 vm = self,
-                a = self.top_value_mut()?,
+                a = self.top_value_mut(frame)?,
                 imm = value,
                 op = BitAnd::bitand,
+                frame = frame,
             }
         }
 
         // or
-        pub(super) fn op_or(&mut self) -> OpResult {
+        pub(super) fn op_or(&mut self, frame: &CallFrame) -> OpResult {
             bin_bitwise! {
                 vm = self,
-                a = self.pop_value()?,
-                b = self.top_value_mut()?,
+                a = self.pop_value(frame)?,
+                b = self.top_value_mut(frame)?,
                 op = BitOr::bitor,
+                frame = frame,
             }
         }
 
         // ori
-        pub(super) fn op_or_imm(&mut self, value: Value) -> OpResult {
+        pub(super) fn op_or_imm(&mut self, value: Value, frame: &CallFrame) -> OpResult {
             bin_bitwise! {
                 vm = self,
-                a = self.top_value_mut()?,
+                a = self.top_value_mut(frame)?,
                 imm = value,
                 op = BitOr::bitor,
+                frame = frame,
             }
         }
 
         // xor
-        pub(super) fn op_xor(&mut self) -> OpResult {
+        pub(super) fn op_xor(&mut self, frame: &CallFrame) -> OpResult {
             bin_bitwise! {
                 vm = self,
-                a = self.pop_value()?,
-                b = self.top_value_mut()?,
+                a = self.pop_value(frame)?,
+                b = self.top_value_mut(frame)?,
                 op = BitXor::bitxor,
+                frame = frame,
             }
         }
 
         // xori
-        pub(super) fn op_xor_imm(&mut self, value: Value) -> OpResult {
+        pub(super) fn op_xor_imm(&mut self, value: Value, frame: &CallFrame) -> OpResult {
             bin_bitwise! {
                 vm = self,
-                a = self.top_value_mut()?,
+                a = self.top_value_mut(frame)?,
                 imm = value,
                 op = BitXor::bitxor,
+                frame = frame,
             }
         }
 
         // not
-        pub(super) fn op_not(&mut self) -> OpResult {
-            let value = self.top_value_mut()?;
+        pub(super) fn op_not(&mut self, frame: &CallFrame) -> OpResult {
+            let value = self.top_value_mut(frame)?;
 
             match value {
                 Value::UInt(val) => {
@@ -852,180 +878,194 @@ mod imp {
                 Value::Address(val) => {
                     *val = !*val;
                 }
-                _ => return Err(self.error(VmErrorKind::Type)),
+                _ => return Err(self.error(VmErrorKind::Type, frame)),
             }
 
             Ok(Transition::Continue)
         }
 
         // shr
-        pub(super) fn op_shr(&mut self) -> OpResult {
+        pub(super) fn op_shr(&mut self, frame: &CallFrame) -> OpResult {
             bin_shift! {
                 vm = self,
-                a = self.pop_value()?,
-                b = self.top_value_mut()?,
+                a = self.pop_value(frame)?,
+                b = self.top_value_mut(frame)?,
                 op = checked_shr,
+                frame = frame,
             }
         }
 
         // shri
-        pub(super) fn op_shr_imm(&mut self, value: Value) -> OpResult {
+        pub(super) fn op_shr_imm(&mut self, value: Value, frame: &CallFrame) -> OpResult {
             bin_shift! {
                 vm = self,
-                a = self.top_value_mut()?,
+                a = self.top_value_mut(frame)?,
                 imm = value,
                 op = checked_shr,
+                frame = frame,
             }
         }
 
         // shl
-        pub(super) fn op_shl(&mut self) -> OpResult {
+        pub(super) fn op_shl(&mut self, frame: &CallFrame) -> OpResult {
             bin_shift! {
                 vm = self,
-                a = self.pop_value()?,
-                b = self.top_value_mut()?,
+                a = self.pop_value(frame)?,
+                b = self.top_value_mut(frame)?,
                 op = checked_shl,
+                frame = frame,
             }
         }
 
         // shli
-        pub(super) fn op_shl_imm(&mut self, value: Value) -> OpResult {
+        pub(super) fn op_shl_imm(&mut self, value: Value, frame: &CallFrame) -> OpResult {
             bin_shift! {
                 vm = self,
-                a = self.top_value_mut()?,
+                a = self.top_value_mut(frame)?,
                 imm = value,
                 op = checked_shl,
+                frame = frame,
             }
         }
 
         // eq
-        pub(super) fn op_eq(&mut self) -> OpResult {
+        pub(super) fn op_eq(&mut self, frame: &CallFrame) -> OpResult {
             bin_compare! {
                 vm = self,
-                a = self.pop_value()?,
-                b = self.top_value_mut()?,
+                a = self.pop_value(frame)?,
+                b = self.top_value_mut(frame)?,
                 null = true,
                 op = PartialEq::eq,
+                frame = frame,
             }
         }
 
         // eqi
-        pub(super) fn op_eq_imm(&mut self, value: Value) -> OpResult {
+        pub(super) fn op_eq_imm(&mut self, value: Value, frame: &CallFrame) -> OpResult {
             bin_compare! {
                 vm = self,
-                a = self.top_value_mut()?,
+                a = self.top_value_mut(frame)?,
                 imm = value,
                 null = true,
                 op = PartialEq::eq,
+                frame = frame,
             }
         }
 
         // gt
-        pub(super) fn op_gt(&mut self) -> OpResult {
+        pub(super) fn op_gt(&mut self, frame: &CallFrame) -> OpResult {
             bin_compare! {
                 vm = self,
-                a = self.pop_value()?,
-                b = self.top_value_mut()?,
+                a = self.pop_value(frame)?,
+                b = self.top_value_mut(frame)?,
                 null = false,
                 op = PartialOrd::gt,
+                frame = frame,
             }
         }
 
         // gti
-        pub(super) fn op_gt_imm(&mut self, value: Value) -> OpResult {
+        pub(super) fn op_gt_imm(&mut self, value: Value, frame: &CallFrame) -> OpResult {
             bin_compare! {
                 vm = self,
-                a = self.top_value_mut()?,
+                a = self.top_value_mut(frame)?,
                 imm = value,
                 null = false,
                 op = PartialOrd::gt,
+                frame = frame,
             }
         }
 
         // ge
-        pub(super) fn op_ge(&mut self) -> OpResult {
+        pub(super) fn op_ge(&mut self, frame: &CallFrame) -> OpResult {
             bin_compare! {
                 vm = self,
-                a = self.pop_value()?,
-                b = self.top_value_mut()?,
+                a = self.pop_value(frame)?,
+                b = self.top_value_mut(frame)?,
                 null = true,
                 op = PartialOrd::ge,
+                frame = frame,
             }
         }
 
         // gei
-        pub(super) fn op_ge_imm(&mut self, value: Value) -> OpResult {
+        pub(super) fn op_ge_imm(&mut self, value: Value, frame: &CallFrame) -> OpResult {
             bin_compare! {
                 vm = self,
-                a = self.top_value_mut()?,
+                a = self.top_value_mut(frame)?,
                 imm = value,
                 null = true,
                 op = PartialOrd::ge,
+                frame = frame,
             }
         }
 
         // lt
-        pub(super) fn op_lt(&mut self) -> OpResult {
+        pub(super) fn op_lt(&mut self, frame: &CallFrame) -> OpResult {
             bin_compare! {
                 vm = self,
-                a = self.pop_value()?,
-                b = self.top_value_mut()?,
+                a = self.pop_value(frame)?,
+                b = self.top_value_mut(frame)?,
                 null = false,
                 op = PartialOrd::lt,
+                frame = frame,
             }
         }
 
         // lti
-        pub(super) fn op_lt_imm(&mut self, value: Value) -> OpResult {
+        pub(super) fn op_lt_imm(&mut self, value: Value, frame: &CallFrame) -> OpResult {
             bin_compare! {
                 vm = self,
-                a = self.top_value_mut()?,
+                a = self.top_value_mut(frame)?,
                 imm = value,
                 null = false,
                 op = PartialOrd::lt,
+                frame = frame,
             }
         }
 
         // le
-        pub(super) fn op_le(&mut self) -> OpResult {
+        pub(super) fn op_le(&mut self, frame: &CallFrame) -> OpResult {
             bin_compare! {
                 vm = self,
-                a = self.pop_value()?,
-                b = self.top_value_mut()?,
+                a = self.pop_value(frame)?,
+                b = self.top_value_mut(frame)?,
                 null = true,
                 op = PartialOrd::le,
+                frame = frame,
             }
         }
 
         // lei
-        pub(super) fn op_le_imm(&mut self, value: Value) -> OpResult {
+        pub(super) fn op_le_imm(&mut self, value: Value, frame: &CallFrame) -> OpResult {
             bin_compare! {
                 vm = self,
-                a = self.top_value_mut()?,
+                a = self.top_value_mut(frame)?,
                 imm = value,
                 null = true,
                 op = PartialOrd::le,
+                frame = frame,
             }
         }
 
         // jmp
-        pub(super) fn op_jump(&mut self) -> OpResult {
-            let address = self.pop_address()?;
+        pub(super) fn op_jump(&mut self, frame: &mut CallFrame) -> OpResult {
+            let address = self.pop_address(frame)?;
 
-            self.op_jump_imm(address)
+            self.op_jump_imm(address, frame)
         }
 
         // jmpi
-        pub(super) fn op_jump_imm(&mut self, address: usize) -> OpResult {
-            self.frame.ip = self.frame.start + address;
+        pub(super) fn op_jump_imm(&mut self, address: usize, frame: &mut CallFrame) -> OpResult {
+            frame.ip = frame.start + address;
 
             Ok(Transition::Jump)
         }
 
         // jmpc
-        pub(super) fn op_jump_cond(&mut self) -> OpResult {
-            if self.pop_bool()? {
-                self.op_jump()
+        pub(super) fn op_jump_cond(&mut self, frame: &mut CallFrame) -> OpResult {
+            if self.pop_bool(frame)? {
+                self.op_jump(frame)
             } else {
                 Ok(Transition::Continue)
             }
@@ -1038,122 +1078,119 @@ mod imp {
         }
 
         // jmpci
-        pub(super) fn op_jump_cond_imm(&mut self, address: usize) -> OpResult {
-            if self.pop_bool()? {
-                self.op_jump_imm(address)
+        pub(super) fn op_jump_cond_imm(&mut self, address: usize, frame: &mut CallFrame) -> OpResult {
+            if self.pop_bool(frame)? {
+                self.op_jump_imm(address, frame)
             } else {
                 Ok(Transition::Continue)
             }
         }
 
         // call
-        pub(super) fn op_call(&mut self) -> OpResult {
+        pub(super) fn op_call(&mut self, frame: &CallFrame) -> OpResult {
             let func = self.pop_function()?;
             // let symbol = self.pop_symbol()?;
 
-            self.op_call_imm(func)
+            self.op_call_imm(func, frame)
         }
 
         // calli
-        pub(super) fn op_call_imm(&mut self, func: NewFunction) -> OpResult {
-            let new_base = self.frame.stack_base + self.frame.locals;
+        pub(super) fn op_call_imm(&mut self, func: NewFunction, frame: &CallFrame) -> OpResult {
+            let new_base = frame.stack_base + frame.locals;
 
-            self.push_frame(self.frame)?;
-            self.frame = CallFrame::new(func, new_base, 0);
+            self.run_function(func, new_base);
 
-            Ok(Transition::Jump)
+            Ok(Transition::Continue)
         }
 
         // calln
-        pub(super) fn op_call_native(&mut self, symbol: Symbol) -> OpResult {
-            let native = self.resolve_native_function(symbol)?;
+        pub(super) fn op_call_native(&mut self, symbol: Symbol, frame: &CallFrame) -> OpResult {
+            let native = self.resolve_native_function(symbol, frame)?;
 
             let value = native(self)?;
 
             if !value.is_null() {
-                self.push_value(value)?;
+                self.push_value(value, frame)?;
             }
 
             Ok(Transition::Continue)
         }
 
         // ret
-        pub(super) fn op_ret(&mut self) -> OpResult {
-            let new_stack_len = self.frame.stack_base + self.frame.locals + 1;
-            self.frame = self.pop_frame()?;
-
+        pub(super) fn op_ret(&mut self, frame: &CallFrame) -> OpResult {
+            let new_stack_len = frame.stack_base + frame.locals + 1;
             self.data_stack.truncate(new_stack_len);
 
-            Ok(Transition::Continue)
+            Ok(Transition::Return)
         }
 
         // castu
-        pub(super) fn op_cast_uint(&mut self) -> OpResult {
-            let cast = match self.pop_value()? {
+        pub(super) fn op_cast_uint(&mut self, frame: &CallFrame) -> OpResult {
+            let cast = match self.pop_value(frame)? {
                 Value::UInt(v) => Value::UInt(v),
                 Value::SInt(v) => Value::UInt(v as u64),
                 Value::Float(v) => Value::UInt(v as u64),
                 Value::Bool(v) => Value::UInt(v as u64),
                 Value::Char(v) => Value::UInt(v as u64),
-                _ => return Err(self.error(VmErrorKind::Type)),
+                _ => return Err(self.error(VmErrorKind::Type, frame)),
             };
 
-            self.push_value(cast)?;
+            self.push_value(cast, frame)?;
 
             Ok(Transition::Continue)
         }
 
         // casts
-        pub(super) fn op_cast_sint(&mut self) -> OpResult {
-            let cast = match self.pop_value()? {
+        pub(super) fn op_cast_sint(&mut self, frame: &CallFrame) -> OpResult {
+            let cast = match self.pop_value(frame)? {
                 Value::UInt(v) => Value::SInt(v as i64),
                 Value::SInt(v) => Value::SInt(v),
                 Value::Float(v) => Value::SInt(v as i64),
                 Value::Bool(v) => Value::SInt(v as i64),
                 Value::Char(v) => Value::SInt(v as i64),
-                _ => return Err(self.error(VmErrorKind::Type)),
+                _ => return Err(self.error(VmErrorKind::Type, frame)),
             };
 
-            self.push_value(cast)?;
+            self.push_value(cast, frame)?;
 
             Ok(Transition::Continue)
         }
 
         // castf
-        pub(super) fn op_cast_float(&mut self) -> OpResult {
-            let cast = match self.pop_value()? {
+        pub(super) fn op_cast_float(&mut self, frame: &CallFrame) -> OpResult {
+            let cast = match self.pop_value(frame)? {
                 Value::UInt(v) => Value::Float(v as f64),
                 Value::SInt(v) => Value::Float(v as f64),
                 Value::Float(v) => Value::Float(v),
                 Value::Bool(v) => Value::Float(v as u64 as f64),
                 Value::Char(v) => Value::Float(v as u64 as f64),
-                _ => return Err(self.error(VmErrorKind::Type)),
+                _ => return Err(self.error(VmErrorKind::Type, frame)),
             };
 
-            self.push_value(cast)?;
+            self.push_value(cast, frame)?;
 
             Ok(Transition::Continue)
         }
 
         // castb
-        pub(super) fn op_cast_bool(&mut self) -> OpResult {
-            let cast = match self.pop_value()? {
+        pub(super) fn op_cast_bool(&mut self, frame: &CallFrame) -> OpResult {
+            let cast = match self.pop_value(frame)? {
                 Value::UInt(v) => Value::Bool(v != 0),
                 Value::SInt(v) => Value::Bool(v != 0),
                 Value::Float(v) => Value::Bool(v != 0.0),
                 Value::Bool(v) => Value::Bool(v),
                 Value::Char(v) => Value::Bool(v != '\0'),
-                _ => return Err(self.error(VmErrorKind::Type)),
+                _ => return Err(self.error(VmErrorKind::Type, frame)),
             };
 
-            self.push_value(cast)?;
+            self.push_value(cast, frame)?;
 
             Ok(Transition::Continue)
         }
 
         // dbg
-        pub(super) fn op_dbg(&self, index: usize) -> OpResult {
-            let value = self.get_value(index).unwrap_or(Value::Null);
+        pub(super) fn op_dbg(&self, index: usize, frame: &CallFrame) -> OpResult {
+            let value = self.get_value(index, frame).unwrap_or(Value::Null);
 
             match value {
                 reference @ Value::Reference(v) => {
@@ -1176,7 +1213,7 @@ mod imp {
         }
 
         // dbgvm
-        pub(super) fn op_dbg_vm(&self) -> OpResult {
+        pub(super) fn op_dbg_vm(&self, frame: &CallFrame) -> OpResult {
             eprintln!("{self:#?}");
 
             Ok(Transition::Continue)


### PR DESCRIPTION
Despite the massive amount of changes,  This does exactly one thing: Converts from a heap-based call stack to using the native stack instead by using recursion to create stack call frames. This improves performance in the example program (in main.rs) by about 25% from initial testing.